### PR TITLE
Modernisation round 2: XML docs, tiered state names, drop 4.4

### DIFF
--- a/MODERNISATION_CHECKLIST.md
+++ b/MODERNISATION_CHECKLIST.md
@@ -84,11 +84,12 @@ Nice-to-have improvements that enhance developer experience.
   - Risk: Very low (minor performance improvement)
   - **COMPLETED**: Updated to use `SourceText.From(kvp.Value, Encoding.UTF8)`. Added required using statements for `System.Text` and `Microsoft.CodeAnalysis.Text`. Modern Roslyn best practice with explicit UTF-8 encoding.
 
-- [ ] **3.2 Generate file-scoped namespaces**
-  - File: `src/SuperFluid/Internal/Services/FluidGeneratorService.cs:34-69`
+- [x] **3.2 Generate file-scoped namespaces** ✅
+  - File: `src/SuperFluid/Internal/Services/FluidGeneratorService.cs`
   - Issue: Generated code uses traditional namespace blocks
   - Fix: Change generated code to use `namespace X;` instead of `namespace X { }`
   - Risk: Very low (cosmetic change to generated code)
+  - **COMPLETED (April 2026)**: Verified both generator emit sites (`GenerateCompoundInterface` and `GenerateStateSource`) already emit `namespace X;` file-scoped syntax. The change landed as part of an earlier refactor — the checklist was stale. Test fixtures in `FluidGeneratorServiceTests` already assert file-scoped namespace output.
 
 - [x] **3.3 Update package metadata** ✅
   - File: `src/SuperFluid/SuperFluid.csproj:14`
@@ -136,11 +137,12 @@ Larger features that can be tackled later.
   - Benefit: Better developer experience (mentioned in README as planned)
   - Risk: Medium (new feature area)
 
-- [ ] **4.2 Add XML documentation support**
+- [x] **4.2 Add XML documentation support** ✅
   - Files: YAML schema and generator
   - Feature: Optional `Description` fields in YAML that generate `/// <summary>` comments
   - Benefit: Self-documenting generated interfaces
   - Risk: Low (additive feature)
+  - **COMPLETED (April 2026)**: Added optional `Description` field to `FluidApiDefinition` (compound interface) and `FluidApiMethodDefinition` (each method + initial state). Threaded through `FluidApiModel` / `FluidApiMethod`. New `FormatXmlDoc` helper in `FluidGeneratorService` escapes `&`, `<`, `>` and emits `///` lines one-per-source-line with correct indentation. Missing descriptions produce zero `///` output — existing fixtures unchanged. 6 new tests (XML escaping, multi-line block scalars, interface- and method-level descriptions, missing description, null handling).
 
 - [ ] **4.3 Improve state name generation**
   - File: `src/SuperFluid/Internal/Model/FluidApiState.cs:8`

--- a/MODERNISATION_CHECKLIST.md
+++ b/MODERNISATION_CHECKLIST.md
@@ -149,11 +149,10 @@ Larger features that can be tackled later.
   - Feature: Maximum name length with ellipsis or hash-based names
   - Risk: Medium (changes core naming logic)
 
-- [ ] **4.4 Multi-target framework support**
+- [~] **4.4 Multi-target framework support** — WON'T DO
   - File: `src/SuperFluid/SuperFluid.csproj`
   - Feature: Target `net6.0` or `net8.0` alongside `netstandard2.0`
-  - Benefit: Better performance and newer APIs while maintaining compatibility
-  - Risk: Medium (build and packaging complexity)
+  - **Dropped (April 2026)**: Roslyn source generators must load as netstandard2.0 — that's what the Roslyn host picks up from `analyzers/dotnet/cs/`. A multi-targeted net8.0 assembly would sit in the nupkg unused, since `DevelopmentDependency=true` and `IncludeBuildOutput=false` explicitly exclude SuperFluid as a runtime library. Modern APIs would be unavailable at generator runtime regardless. No benefit for the current single-use (analyzer-only) packaging model.
 
 ---
 

--- a/src/SuperFluid.Tests/SourceGenerators/FluidGeneratorServiceTests.cs
+++ b/src/SuperFluid.Tests/SourceGenerators/FluidGeneratorServiceTests.cs
@@ -595,6 +595,151 @@ public class FluidGeneratorServiceTests
 		result.Diagnostics[0].Id.ShouldBe("SF0016");
 	}
 
+	// -------------------------------------------------------------------------
+	// XML documentation tests
+	// -------------------------------------------------------------------------
+
+	[Fact]
+	public void GenerateEmitsXmlDocOnCompoundInterfaceWhenDescriptionProvided()
+	{
+		string yaml = """
+		              Name: "ITestActor"
+		              Namespace: "Test"
+		              Description: "My car actor"
+		              InitialState:
+		                Name: "Start"
+		                CanTransitionTo: ["DoSomething"]
+		              Methods:
+		                - Name: "DoSomething"
+		                  CanTransitionTo: []
+		              """;
+
+		GenerationResult result = _sut.Generate(yaml, "test.fluid.yml");
+
+		result.IsSuccess.ShouldBeTrue();
+		string compoundSource = result.GeneratedFiles!["ITestActor.fluid.g.cs"];
+		compoundSource.ShouldContain("/// <summary>");
+		compoundSource.ShouldContain("/// My car actor");
+		compoundSource.ShouldContain("/// </summary>");
+		int docIndex = compoundSource.IndexOf("/// <summary>", StringComparison.Ordinal);
+		int interfaceIndex = compoundSource.IndexOf("public interface ITestActor", StringComparison.Ordinal);
+		docIndex.ShouldBeLessThan(interfaceIndex);
+	}
+
+	[Fact]
+	public void GenerateEmitsXmlDocOnMethodWhenDescriptionProvided()
+	{
+		string yaml = """
+		              Name: "ITestActor"
+		              Namespace: "Test"
+		              InitialState:
+		                Name: "Start"
+		                CanTransitionTo: ["Lock"]
+		              Methods:
+		                - Name: "Lock"
+		                  Description: "Locks the car"
+		                  CanTransitionTo: ["Start"]
+		              """;
+
+		GenerationResult result = _sut.Generate(yaml, "test.fluid.yml");
+
+		result.IsSuccess.ShouldBeTrue();
+		string lockStateSource = result.GeneratedFiles!.Values.First(s => s.Contains("public ICanStart Lock()"));
+		lockStateSource.ShouldContain("/// <summary>");
+		lockStateSource.ShouldContain("/// Locks the car");
+		lockStateSource.ShouldContain("/// </summary>");
+		int docIndex = lockStateSource.IndexOf("/// <summary>", StringComparison.Ordinal);
+		int methodIndex = lockStateSource.IndexOf("public ICanStart Lock()", StringComparison.Ordinal);
+		docIndex.ShouldBeLessThan(methodIndex);
+	}
+
+	[Fact]
+	public void GenerateEmitsXmlDocOnInitialMethodInCompoundInterfaceWhenDescriptionProvided()
+	{
+		string yaml = """
+		              Name: "ITestActor"
+		              Namespace: "Test"
+		              InitialState:
+		                Name: "Start"
+		                Description: "Initialises the actor"
+		                CanTransitionTo: ["DoSomething"]
+		              Methods:
+		                - Name: "DoSomething"
+		                  CanTransitionTo: []
+		              """;
+
+		GenerationResult result = _sut.Generate(yaml, "test.fluid.yml");
+
+		result.IsSuccess.ShouldBeTrue();
+		string compoundSource = result.GeneratedFiles!["ITestActor.fluid.g.cs"];
+		compoundSource.ShouldContain("/// <summary>");
+		compoundSource.ShouldContain("/// Initialises the actor");
+		compoundSource.ShouldContain("/// </summary>");
+		int docIndex = compoundSource.IndexOf("/// <summary>", StringComparison.Ordinal);
+		int methodIndex = compoundSource.IndexOf("public static abstract", StringComparison.Ordinal);
+		docIndex.ShouldBeLessThan(methodIndex);
+	}
+
+	[Fact]
+	public void GenerateEmitsMultiLineXmlDocWhenDescriptionContainsNewlines()
+	{
+		string yaml = "Name: \"ITestActor\"\nNamespace: \"Test\"\nDescription: \"Line one\\nLine two\"\nInitialState:\n  Name: \"Start\"\n  CanTransitionTo: [\"DoSomething\"]\nMethods:\n  - Name: \"DoSomething\"\n    CanTransitionTo: []";
+
+		GenerationResult result = _sut.Generate(yaml, "test.fluid.yml");
+
+		result.IsSuccess.ShouldBeTrue();
+		string compoundSource = result.GeneratedFiles!["ITestActor.fluid.g.cs"];
+		compoundSource.ShouldContain("/// Line one");
+		compoundSource.ShouldContain("/// Line two");
+	}
+
+	[Fact]
+	public void GenerateEscapesXmlSpecialCharactersInDescription()
+	{
+		string yaml = """
+		              Name: "ITestActor"
+		              Namespace: "Test"
+		              Description: "Returns List<T> of items & more"
+		              InitialState:
+		                Name: "Start"
+		                CanTransitionTo: ["DoSomething"]
+		              Methods:
+		                - Name: "DoSomething"
+		                  CanTransitionTo: []
+		              """;
+
+		GenerationResult result = _sut.Generate(yaml, "test.fluid.yml");
+
+		result.IsSuccess.ShouldBeTrue();
+		string compoundSource = result.GeneratedFiles!["ITestActor.fluid.g.cs"];
+		compoundSource.ShouldContain("Returns List&lt;T&gt; of items &amp; more");
+		compoundSource.ShouldNotContain("List<T>");
+		compoundSource.ShouldNotContain("items & more");
+	}
+
+	[Fact]
+	public void GenerateProducesNoXmlDocLinesWhenDescriptionIsAbsent()
+	{
+		string yaml = """
+		              Name: "ITestActor"
+		              Namespace: "Test"
+		              InitialState:
+		                Name: "Start"
+		                CanTransitionTo: ["DoSomething"]
+		              Methods:
+		                - Name: "DoSomething"
+		                  CanTransitionTo: []
+		              """;
+
+		GenerationResult result = _sut.Generate(yaml, "test.fluid.yml");
+
+		result.IsSuccess.ShouldBeTrue();
+		foreach (string source in result.GeneratedFiles!.Values)
+		{
+			source.ShouldNotContain("///");
+		}
+	}
+
 	private const string CanEnterOrLockSource = """
 	                                            namespace SuperFluid.Tests.Cars;
 

--- a/src/SuperFluid.Tests/SourceGenerators/FluidGeneratorServiceTests.cs
+++ b/src/SuperFluid.Tests/SourceGenerators/FluidGeneratorServiceTests.cs
@@ -235,6 +235,366 @@ public class FluidGeneratorServiceTests
 		result.Diagnostics[0].Id.ShouldBe("SF0010");
 	}
 
+	// -------------------------------------------------------------------------
+	// Tiered state naming tests
+	// -------------------------------------------------------------------------
+
+	[Fact]
+	public void Tier1NamingProducesShortFormForSmallStates()
+	{
+		// The demo YAML produces states like ICanEnterOrLock which are ≤ 60 chars — ensure unchanged
+		GenerationResult result = _sut.Generate(_rawYml, "test.fluid.yml");
+
+		result.IsSuccess.ShouldBeTrue();
+		result.GeneratedFiles!.ShouldContainKey("ICanEnterOrLock.fluid.g.cs");
+		result.GeneratedFiles!.ShouldContainKey("ICanExitOrStart.fluid.g.cs");
+		result.GeneratedFiles!.ShouldContainKey("ICanUnlock.fluid.g.cs");
+	}
+
+	[Fact]
+	public void Tier2NamingProducesTruncatedFormWhenTier1ExceedsLimit()
+	{
+		// Construct a state with 8 methods whose Tier-1 name exceeds 60 chars.
+		// Alphabetical order: ActionAlpha, ActionBeta, ActionDelta, ActionEpsilon, ActionEta, ActionGamma, ActionTheta, ActionZeta
+		// Tier-2 name: ICanActionAlphaOrActionBetaOr6More
+		string yaml = """
+		              Name: "ILargeActor"
+		              Namespace: "Test.Large"
+		              InitialState:
+		                Name: "Begin"
+		                CanTransitionTo:
+		                  - "ActionAlpha"
+		                  - "ActionBeta"
+		                  - "ActionDelta"
+		                  - "ActionEpsilon"
+		                  - "ActionEta"
+		                  - "ActionGamma"
+		                  - "ActionTheta"
+		                  - "ActionZeta"
+		              Methods:
+		                - Name: "ActionAlpha"
+		                  CanTransitionTo: []
+		                - Name: "ActionBeta"
+		                  CanTransitionTo: []
+		                - Name: "ActionDelta"
+		                  CanTransitionTo: []
+		                - Name: "ActionEpsilon"
+		                  CanTransitionTo: []
+		                - Name: "ActionEta"
+		                  CanTransitionTo: []
+		                - Name: "ActionGamma"
+		                  CanTransitionTo: []
+		                - Name: "ActionTheta"
+		                  CanTransitionTo: []
+		                - Name: "ActionZeta"
+		                  CanTransitionTo: []
+		              """;
+
+		GenerationResult result = _sut.Generate(yaml, "test.fluid.yml");
+
+		result.IsSuccess.ShouldBeTrue();
+
+		// Verify the Tier-1 name would have been too long
+		string tier1Name = "ICanActionAlphaOrActionBetaOrActionDeltaOrActionEpsilonOrActionEtaOrActionGammaOrActionThetaOrActionZeta";
+		tier1Name.Length.ShouldBeGreaterThan(60);
+
+		// Assert the Tier-2 truncated name is used instead
+		result.GeneratedFiles!.ShouldContainKey("ICanActionAlphaOrActionBetaOr6More.fluid.g.cs");
+		result.GeneratedFiles!.ShouldNotContainKey($"{tier1Name}.fluid.g.cs");
+	}
+
+	[Fact]
+	public void Tier2CollisionPromotesBothStatesToTier3()
+	{
+		// Two states share the same first two alphabetical methods (Aardvark, Baboon) but differ in the rest.
+		// Both should be promoted to Tier 3 bucket names rather than getting the same Tier-2 name.
+		// State 1 (reachable via MethodA): {Aardvark, Baboon, Cheetah, Donkey, Elephant, Flamingo, Gorilla, Hippo}
+		// State 2 (reachable via MethodB): {Aardvark, Baboon, Iguana, Jaguar, Kangaroo, Lion, Meerkat, Numbat}
+		// Both produce Tier-2: ICanAardvarkOrBaboonOr6More → collision → both get Tier-3 names
+		string yaml = """
+		              Name: "ICollisionActor"
+		              Namespace: "Test.Collision"
+		              InitialState:
+		                Name: "Begin"
+		                CanTransitionTo:
+		                  - "MethodA"
+		                  - "MethodB"
+		              Methods:
+		                - Name: "MethodA"
+		                  CanTransitionTo:
+		                    - "Aardvark"
+		                    - "Baboon"
+		                    - "Cheetah"
+		                    - "Donkey"
+		                    - "Elephant"
+		                    - "Flamingo"
+		                    - "Gorilla"
+		                    - "Hippo"
+		                - Name: "MethodB"
+		                  CanTransitionTo:
+		                    - "Aardvark"
+		                    - "Baboon"
+		                    - "Iguana"
+		                    - "Jaguar"
+		                    - "Kangaroo"
+		                    - "Lion"
+		                    - "Meerkat"
+		                    - "Numbat"
+		                - Name: "Aardvark"
+		                  CanTransitionTo: []
+		                - Name: "Baboon"
+		                  CanTransitionTo: []
+		                - Name: "Cheetah"
+		                  CanTransitionTo: []
+		                - Name: "Donkey"
+		                  CanTransitionTo: []
+		                - Name: "Elephant"
+		                  CanTransitionTo: []
+		                - Name: "Flamingo"
+		                  CanTransitionTo: []
+		                - Name: "Gorilla"
+		                  CanTransitionTo: []
+		                - Name: "Hippo"
+		                  CanTransitionTo: []
+		                - Name: "Iguana"
+		                  CanTransitionTo: []
+		                - Name: "Jaguar"
+		                  CanTransitionTo: []
+		                - Name: "Kangaroo"
+		                  CanTransitionTo: []
+		                - Name: "Lion"
+		                  CanTransitionTo: []
+		                - Name: "Meerkat"
+		                  CanTransitionTo: []
+		                - Name: "Numbat"
+		                  CanTransitionTo: []
+		              """;
+
+		GenerationResult result = _sut.Generate(yaml, "test.fluid.yml");
+
+		result.IsSuccess.ShouldBeTrue();
+
+		// Neither state should have the colliding Tier-2 name
+		result.GeneratedFiles!.ShouldNotContainKey("ICanAardvarkOrBaboonOr6More.fluid.g.cs");
+
+		// Both states should have Tier-3 bucket names
+		string[] tier3Keys = result.GeneratedFiles!.Keys.Where(k => k.Contains("ICanDoManyCollisionActorState")).ToArray();
+		tier3Keys.Length.ShouldBe(2, "Both colliding states should receive Tier-3 names");
+	}
+
+	[Fact]
+	public void Tier3HashIsDeterministicAcrossRuns()
+	{
+		// Verify that running the generator twice on the same input yields identical filenames.
+		// This specifically tests determinism of the SHA-256 hash used in Tier-3 naming.
+		string yaml = """
+		              Name: "ICollisionActor"
+		              Namespace: "Test.Collision"
+		              InitialState:
+		                Name: "Begin"
+		                CanTransitionTo:
+		                  - "MethodA"
+		                  - "MethodB"
+		              Methods:
+		                - Name: "MethodA"
+		                  CanTransitionTo:
+		                    - "Aardvark"
+		                    - "Baboon"
+		                    - "Cheetah"
+		                    - "Donkey"
+		                    - "Elephant"
+		                    - "Flamingo"
+		                    - "Gorilla"
+		                    - "Hippo"
+		                - Name: "MethodB"
+		                  CanTransitionTo:
+		                    - "Aardvark"
+		                    - "Baboon"
+		                    - "Iguana"
+		                    - "Jaguar"
+		                    - "Kangaroo"
+		                    - "Lion"
+		                    - "Meerkat"
+		                    - "Numbat"
+		                - Name: "Aardvark"
+		                  CanTransitionTo: []
+		                - Name: "Baboon"
+		                  CanTransitionTo: []
+		                - Name: "Cheetah"
+		                  CanTransitionTo: []
+		                - Name: "Donkey"
+		                  CanTransitionTo: []
+		                - Name: "Elephant"
+		                  CanTransitionTo: []
+		                - Name: "Flamingo"
+		                  CanTransitionTo: []
+		                - Name: "Gorilla"
+		                  CanTransitionTo: []
+		                - Name: "Hippo"
+		                  CanTransitionTo: []
+		                - Name: "Iguana"
+		                  CanTransitionTo: []
+		                - Name: "Jaguar"
+		                  CanTransitionTo: []
+		                - Name: "Kangaroo"
+		                  CanTransitionTo: []
+		                - Name: "Lion"
+		                  CanTransitionTo: []
+		                - Name: "Meerkat"
+		                  CanTransitionTo: []
+		                - Name: "Numbat"
+		                  CanTransitionTo: []
+		              """;
+
+		GenerationResult firstRun  = _sut.Generate(yaml, "test.fluid.yml");
+		GenerationResult secondRun = _sut.Generate(yaml, "test.fluid.yml");
+
+		firstRun.IsSuccess.ShouldBeTrue();
+		secondRun.IsSuccess.ShouldBeTrue();
+
+		string[] firstKeys  = firstRun.GeneratedFiles!.Keys.OrderBy(k => k).ToArray();
+		string[] secondKeys = secondRun.GeneratedFiles!.Keys.OrderBy(k => k).ToArray();
+
+		firstKeys.ShouldBeEquivalentTo(secondKeys, "Tier-3 names must be deterministic across runs");
+	}
+
+	[Fact]
+	public void Tier4UserOverrideAppliesUserDeclaredStateName()
+	{
+		string yaml = """
+		              Name: "ICarActor"
+		              Namespace: "SuperFluid.Tests.Cars"
+		              InitialState:
+		                Name: "Initialize"
+		                CanTransitionTo:
+		                  - "Unlock"
+		              StateNames:
+		                - Name: "ICarUnlocked"
+		                  Transitions:
+		                    - "Enter"
+		                    - "Lock"
+		              Methods:
+		                - Name: "Unlock"
+		                  CanTransitionTo:
+		                    - "Lock"
+		                    - "Enter"
+		                - Name: "Lock"
+		                  CanTransitionTo:
+		                    - "Unlock"
+		                - Name: "Enter"
+		                  CanTransitionTo:
+		                    - "Exit"
+		                - Name: "Exit"
+		                  CanTransitionTo: []
+		              """;
+
+		GenerationResult result = _sut.Generate(yaml, "test.fluid.yml");
+
+		result.IsSuccess.ShouldBeTrue();
+		result.GeneratedFiles!.ShouldContainKey("ICarUnlocked.fluid.g.cs", "User-declared state name should be used");
+
+		// The compound interface's base list should include the user-declared name
+		string compoundSource = result.GeneratedFiles!["ICarActor.fluid.g.cs"];
+		compoundSource.ShouldContain("ICarUnlocked");
+	}
+
+	[Fact]
+	public void Tier4UnmatchedStateNameDeclarationReportsSF0014Warning()
+	{
+		// The Transitions list references real methods (both Lock and Enter exist in the state machine)
+		// but the exact combination {Lock} alone doesn't match any synthesised state.
+		// The only state reachable from Initialize has transitions {Lock, Enter}; declaring {Lock} alone
+		// produces no match, triggering SF0014.
+		string yaml = """
+		              Name: "ICarActor"
+		              Namespace: "SuperFluid.Tests.Cars"
+		              InitialState:
+		                Name: "Initialize"
+		                CanTransitionTo:
+		                  - "Unlock"
+		              StateNames:
+		                - Name: "IObsoleteStateName"
+		                  Transitions:
+		                    - "Lock"
+		              Methods:
+		                - Name: "Unlock"
+		                  CanTransitionTo:
+		                    - "Lock"
+		                    - "Enter"
+		                - Name: "Lock"
+		                  CanTransitionTo: []
+		                - Name: "Enter"
+		                  CanTransitionTo: []
+		              """;
+
+		GenerationResult result = _sut.Generate(yaml, "test.fluid.yml");
+
+		// SF0014 is a warning; generation should still succeed for the rest
+		result.IsSuccess.ShouldBeTrue();
+		result.Diagnostics.ShouldNotBeEmpty();
+		result.Diagnostics[0].Id.ShouldBe("SF0014");
+	}
+
+	[Fact]
+	public void Tier4InvalidStateNameIdentifierReportsSF0015Error()
+	{
+		string yaml = """
+		              Name: "ICarActor"
+		              Namespace: "SuperFluid.Tests.Cars"
+		              InitialState:
+		                Name: "Initialize"
+		                CanTransitionTo:
+		                  - "Unlock"
+		              StateNames:
+		                - Name: "Invalid Name With Spaces"
+		                  Transitions:
+		                    - "Unlock"
+		              Methods:
+		                - Name: "Unlock"
+		                  CanTransitionTo: []
+		              """;
+
+		GenerationResult result = _sut.Generate(yaml, "test.fluid.yml");
+
+		result.IsSuccess.ShouldBeFalse();
+		result.Diagnostics[0].Id.ShouldBe("SF0015");
+		result.Diagnostics[0].GetMessage().ShouldContain("Invalid Name With Spaces");
+	}
+
+	[Fact]
+	public void Tier4AmbiguousStateNameDeclarationReportsSF0016Error()
+	{
+		// Both StateNames entries declare different names for the same synthesised state {Enter}.
+		// The state reachable after Unlock has transition set {Enter}.
+		// Two entries both claim it → SF0016 ambiguity error.
+		string yaml = """
+		              Name: "ICarActor"
+		              Namespace: "SuperFluid.Tests.Cars"
+		              InitialState:
+		                Name: "Initialize"
+		                CanTransitionTo:
+		                  - "Unlock"
+		              StateNames:
+		                - Name: "IFirstName"
+		                  Transitions:
+		                    - "Enter"
+		                - Name: "ISecondName"
+		                  Transitions:
+		                    - "Enter"
+		              Methods:
+		                - Name: "Unlock"
+		                  CanTransitionTo:
+		                    - "Enter"
+		                - Name: "Enter"
+		                  CanTransitionTo: []
+		              """;
+
+		GenerationResult result = _sut.Generate(yaml, "test.fluid.yml");
+
+		result.IsSuccess.ShouldBeFalse();
+		result.Diagnostics[0].Id.ShouldBe("SF0016");
+	}
+
 	private const string CanEnterOrLockSource = """
 	                                            namespace SuperFluid.Tests.Cars;
 

--- a/src/SuperFluid/Internal/Definitions/FluidApiDefinition.cs
+++ b/src/SuperFluid/Internal/Definitions/FluidApiDefinition.cs
@@ -5,9 +5,10 @@ namespace SuperFluid.Internal.Definitions;
 [DebuggerDisplay("{Name}")]
 internal record FluidApiDefinition
 {
-    public required string                    Name         { get; init; }
-    public required string                    Namespace    { get; init; }
-    public required FluidApiMethodDefinition  InitialState { get; init; }
-    public required List<FluidApiMethodDefinition> Methods { get; init; }
-    public List<StateNameDefinition>?         StateNames   { get; init; }
+    public required string                         Name         { get; init; }
+    public required string                         Namespace    { get; init; }
+    public          string?                        Description  { get; init; }
+    public required FluidApiMethodDefinition       InitialState { get; init; }
+    public required List<FluidApiMethodDefinition> Methods      { get; init; }
+    public          List<StateNameDefinition>?     StateNames   { get; init; }
 }

--- a/src/SuperFluid/Internal/Definitions/FluidApiDefinition.cs
+++ b/src/SuperFluid/Internal/Definitions/FluidApiDefinition.cs
@@ -5,8 +5,9 @@ namespace SuperFluid.Internal.Definitions;
 [DebuggerDisplay("{Name}")]
 internal record FluidApiDefinition
 {
-    public required string Name { get; init; }
-    public required string Namespace { get; init; }
-    public required FluidApiMethodDefinition InitialState { get; init; }
+    public required string                    Name         { get; init; }
+    public required string                    Namespace    { get; init; }
+    public required FluidApiMethodDefinition  InitialState { get; init; }
     public required List<FluidApiMethodDefinition> Methods { get; init; }
+    public List<StateNameDefinition>?         StateNames   { get; init; }
 }

--- a/src/SuperFluid/Internal/Definitions/FluidApiMethodDefinition.cs
+++ b/src/SuperFluid/Internal/Definitions/FluidApiMethodDefinition.cs
@@ -7,9 +7,10 @@ internal record FluidApiMethodDefinition
 {
 	public required string Name { get; init; }
 	public string? ReturnType { get; init; }
+	public string? Description { get; init; }
 	public List<string> CanTransitionTo { get; init; } = [];
-	
+
 	public List<FluidApiArgumentDefinition> Arguments { get; init; } = [];
-	
+
 	public List<FluidGenericArgumentDefinition> GenericArguments { get; init; } = [];
 }

--- a/src/SuperFluid/Internal/Definitions/StateNameDefinition.cs
+++ b/src/SuperFluid/Internal/Definitions/StateNameDefinition.cs
@@ -1,0 +1,7 @@
+namespace SuperFluid.Internal.Definitions;
+
+internal record StateNameDefinition
+{
+    public required string       Name        { get; init; }
+    public List<string>          Transitions { get; init; } = [];
+}

--- a/src/SuperFluid/Internal/Diagnostics/DiagnosticDescriptors.cs
+++ b/src/SuperFluid/Internal/Diagnostics/DiagnosticDescriptors.cs
@@ -119,4 +119,32 @@ internal static class DiagnosticDescriptors
 		category: Category,
 		defaultSeverity: DiagnosticSeverity.Warning,
 		isEnabledByDefault: true);
+
+	// State Naming
+	public static readonly DiagnosticDescriptor UnmatchedStateNameDeclaration = new(
+		id: "SF0014",
+		title: "Unmatched state name declaration",
+		messageFormat: "The StateNames entry '{0}' declares a transition set that does not match any synthesised state. It may have drifted from the current definition.",
+		category: Category,
+		defaultSeverity: DiagnosticSeverity.Warning,
+		isEnabledByDefault: true,
+		description: "A StateNames entry specifies a Transitions list that does not correspond to any state in the generated state machine. Check that the method names are correct and the state still exists.");
+
+	public static readonly DiagnosticDescriptor InvalidStateNameIdentifier = new(
+		id: "SF0015",
+		title: "Invalid state name identifier",
+		messageFormat: "The declared state name '{0}' is not a valid C# identifier",
+		category: Category,
+		defaultSeverity: DiagnosticSeverity.Error,
+		isEnabledByDefault: true,
+		description: "State names declared in StateNames must be valid C# identifiers.");
+
+	public static readonly DiagnosticDescriptor AmbiguousStateNameDeclaration = new(
+		id: "SF0016",
+		title: "Ambiguous state name declaration",
+		messageFormat: "Multiple StateNames entries '{0}' and '{1}' match the same synthesised state",
+		category: Category,
+		defaultSeverity: DiagnosticSeverity.Error,
+		isEnabledByDefault: true,
+		description: "Two or more StateNames entries resolve to the same synthesised state. Remove or correct the duplicate entries.");
 }

--- a/src/SuperFluid/Internal/Exceptions/StateNameException.cs
+++ b/src/SuperFluid/Internal/Exceptions/StateNameException.cs
@@ -1,0 +1,36 @@
+namespace SuperFluid.Internal.Exceptions;
+
+internal sealed class InvalidStateNameIdentifierException : InvalidOperationException
+{
+    public InvalidStateNameIdentifierException(string declaredName)
+        : base($"The declared state name '{declaredName}' is not a valid C# identifier")
+    {
+        DeclaredName = declaredName;
+    }
+
+    public string DeclaredName { get; }
+}
+
+internal sealed class UnmatchedStateNameDeclarationException : InvalidOperationException
+{
+    public UnmatchedStateNameDeclarationException(string declaredName)
+        : base($"The StateNames entry '{declaredName}' does not match any synthesised state")
+    {
+        DeclaredName = declaredName;
+    }
+
+    public string DeclaredName { get; }
+}
+
+internal sealed class AmbiguousStateNameDeclarationException : InvalidOperationException
+{
+    public AmbiguousStateNameDeclarationException(string firstName, string secondName)
+        : base($"Multiple StateNames entries '{firstName}' and '{secondName}' match the same synthesised state")
+    {
+        FirstName  = firstName;
+        SecondName = secondName;
+    }
+
+    public string FirstName  { get; }
+    public string SecondName { get; }
+}

--- a/src/SuperFluid/Internal/Model/FluidApiMethod.cs
+++ b/src/SuperFluid/Internal/Model/FluidApiMethod.cs
@@ -6,11 +6,12 @@ namespace SuperFluid.Internal.Model;
 [DebuggerDisplay("{Name}")]
 internal record FluidApiMethod
 {
-    public FluidApiMethod(string name, string? returnType, IEnumerable<FluidApiMethod> transitions, IEnumerable<FluidApiArgument> args,
+    public FluidApiMethod(string name, string? returnType, string? description, IEnumerable<FluidApiMethod> transitions, IEnumerable<FluidApiArgument> args,
         IEnumerable<FluidGenericArgument> genericArgs)
     {
         Name = name;
         ReturnType = returnType;
+        Description = description;
         CanTransitionTo = [..transitions];
         GenericArguments = [..genericArgs];
 
@@ -23,6 +24,8 @@ internal record FluidApiMethod
     internal string Name { get; init; }
 
     internal string? ReturnType { get; init; }
+
+    internal string? Description { get; init; }
     internal HashSet<FluidApiMethod> CanTransitionTo { get; init; } = [];
 
     internal ImmutableArray<FluidApiArgument> Arguments { get; init; } = [];

--- a/src/SuperFluid/Internal/Model/FluidApiModel.cs
+++ b/src/SuperFluid/Internal/Model/FluidApiModel.cs
@@ -7,6 +7,7 @@ internal record FluidApiModel
 {
     public required string               Name                         { get; init; }
     public required string               Namespace                    { get; init; }
+    public          string?              Description                  { get; init; }
     public required FluidApiMethod       InitialMethod                { get; init; }
 
     // Might actually be able to remove this

--- a/src/SuperFluid/Internal/Model/FluidApiModel.cs
+++ b/src/SuperFluid/Internal/Model/FluidApiModel.cs
@@ -5,13 +5,26 @@ namespace SuperFluid.Internal.Model;
 [DebuggerDisplay("{Name}")]
 internal record FluidApiModel
 {
-	public required string              Name         { get; init; }
-	public required string              Namespace         { get; init; }
-	public required FluidApiMethod       InitialMethod { get; init; }
-	
-	// Might actually be able to remove this
-	public required List<FluidApiMethod> Methods       { get; init; } = [];
+    public required string               Name                         { get; init; }
+    public required string               Namespace                    { get; init; }
+    public required FluidApiMethod       InitialMethod                { get; init; }
 
-	public required FluidApiState InitializerMethodReturnState { get; init; }
-	public required List<FluidApiState> States { get; init; } = [];
+    // Might actually be able to remove this
+    public required List<FluidApiMethod> Methods                      { get; init; } = [];
+
+    public required FluidApiState        InitializerMethodReturnState { get; init; }
+    public required List<FluidApiState>  States                       { get; init; } = [];
+
+    /// <summary>
+    /// Lookup from <see cref="FluidApiState"/> to its generated interface name.
+    /// Single source of truth for state names. Keyed by reference — the record-generated equality
+    /// on <see cref="FluidApiState"/> compares its only field (a mutable <see cref="Dictionary{TKey,TValue}"/>)
+    /// by reference equality, so two distinct <see cref="FluidApiState"/> instances remain distinct keys.
+    /// </summary>
+    public Dictionary<FluidApiState, string> StateNames                 { get; init; } = new();
+
+    /// <summary>
+    /// SF0014 warnings: names declared in StateNames: that did not match any synthesised state.
+    /// </summary>
+    public List<string>                  UnmatchedStateNameWarnings   { get; init; } = [];
 }

--- a/src/SuperFluid/Internal/Model/FluidApiState.cs
+++ b/src/SuperFluid/Internal/Model/FluidApiState.cs
@@ -2,15 +2,13 @@ using System.Diagnostics;
 
 namespace SuperFluid.Internal.Model;
 
-[DebuggerDisplay("{Name}")]
+[DebuggerDisplay("State with {MethodTransitions.Count} transitions")]
 internal record FluidApiState
 {
-	internal string                                    Name              => MethodTransitions.Count == 0 ? "Terminating State" : $"ICan{MethodTransitions.Keys.Select(t => t.Name).OrderBy(n => n, StringComparer.Ordinal).Aggregate((a, b) => $"{a}Or{b}")}";
 	internal Dictionary<FluidApiMethod, FluidApiState> MethodTransitions { get; init; } = new();
 
 	public FluidApiState(Dictionary<FluidApiMethod, FluidApiState> methodTransitions)
 	{
 		MethodTransitions = methodTransitions;
 	}
-
 }

--- a/src/SuperFluid/Internal/Parsers/FluidApiDefinitionParser.cs
+++ b/src/SuperFluid/Internal/Parsers/FluidApiDefinitionParser.cs
@@ -3,35 +3,61 @@ using SuperFluid.Internal.Definitions;
 using SuperFluid.Internal.EqualityComparers;
 using SuperFluid.Internal.Exceptions;
 using SuperFluid.Internal.Model;
+using SuperFluid.Internal.Services;
 
 namespace SuperFluid.Internal.Parsers;
 
 internal class FluidApiDefinitionParser
 {
-	public FluidApiModel Parse(FluidApiDefinition definition)
-	{
-		if (definition is null)
-			throw new ArgumentNullException(nameof(definition));
-		if (definition.Methods is null)
-			throw new ArgumentNullException(nameof(definition.Methods));
-		if (definition.InitialState is null)
-			throw new ArgumentNullException(nameof(definition.InitialState));
+    public FluidApiModel Parse(FluidApiDefinition definition)
+    {
+        if (definition is null)
+            throw new ArgumentNullException(nameof(definition));
+        if (definition.Methods is null)
+            throw new ArgumentNullException(nameof(definition.Methods));
+        if (definition.InitialState is null)
+            throw new ArgumentNullException(nameof(definition.InitialState));
 
-		List<FluidApiMethod> methods = GetMethods(definition, out FluidApiMethod initialMethod);
-		List<FluidApiState>  states  = GetMinimalStates(methods, initialMethod, out FluidApiState initialState);
+        List<FluidApiMethod> methods = GetMethods(definition, out FluidApiMethod initialMethod);
+        List<FluidApiState>  states  = GetMinimalStates(methods, initialMethod, out FluidApiState initialState);
 
-		FluidApiModel model = new()
-							  {
-								  Name                         = definition.Name,
-								  Namespace                    = definition.Namespace,
-								  InitialMethod                = initialMethod,
-								  Methods                      = methods,
-								  InitializerMethodReturnState = initialState,
-								  States                       = states
-							  };
+        // Assign state names using the tiered naming scheme (may throw for SF0015/SF0016)
+        (Dictionary<FluidApiState, string> stateNames, List<string> unmatchedWarnings) = StateNamingService.AssignNames(states, definition);
 
-		return model;
-	}
+        // Empty terminal states are filtered out of `states` but may still appear as destination
+        // references inside non-terminal states' MethodTransitions (or as the initial return state).
+        // Register them in the name map so GenerateMethodSource's
+        // `method.ReturnType ?? model.StateNames[state]` fallback works.
+        foreach (FluidApiState state in states)
+        {
+            foreach (FluidApiState destination in state.MethodTransitions.Values)
+            {
+                if (!stateNames.ContainsKey(destination))
+                {
+                    stateNames[destination] = "Terminating State";
+                }
+            }
+        }
+
+        if (!stateNames.ContainsKey(initialState))
+        {
+            stateNames[initialState] = "Terminating State";
+        }
+
+        FluidApiModel model = new()
+                              {
+                                  Name                         = definition.Name,
+                                  Namespace                    = definition.Namespace,
+                                  InitialMethod                = initialMethod,
+                                  Methods                      = methods,
+                                  InitializerMethodReturnState = initialState,
+                                  States                       = states,
+                                  StateNames                   = stateNames,
+                                  UnmatchedStateNameWarnings   = unmatchedWarnings
+                              };
+
+        return model;
+    }
 
 	private List<FluidApiMethod> GetMethods(FluidApiDefinition definition, out FluidApiMethod initialMethod)
 	{
@@ -128,4 +154,5 @@ internal class FluidApiDefinitionParser
 
 		return matches[0];
 	}
+
 }

--- a/src/SuperFluid/Internal/Parsers/FluidApiDefinitionParser.cs
+++ b/src/SuperFluid/Internal/Parsers/FluidApiDefinitionParser.cs
@@ -48,6 +48,7 @@ internal class FluidApiDefinitionParser
                               {
                                   Name                         = definition.Name,
                                   Namespace                    = definition.Namespace,
+                                  Description                  = definition.Description,
                                   InitialMethod                = initialMethod,
                                   Methods                      = methods,
                                   InitializerMethodReturnState = initialState,
@@ -124,7 +125,7 @@ internal class FluidApiDefinitionParser
 
 		List<FluidGenericArgument> genericArgs = method.GenericArguments.Select(a => new FluidGenericArgument(a.Name, a.Constraints)).ToList();
 
-		FluidApiMethod newMethod = new(method.Name, method.ReturnType, [], args, genericArgs);
+		FluidApiMethod newMethod = new(method.Name, method.ReturnType, method.Description, [], args, genericArgs);
 		stateDict.Add(method, newMethod);
 
 		List<FluidApiMethodDefinition> transitionDefinitions = method.CanTransitionTo.Select(m => FindMethodByName(definition, m, method.Name)).ToList();

--- a/src/SuperFluid/Internal/Services/FluidGeneratorService.cs
+++ b/src/SuperFluid/Internal/Services/FluidGeneratorService.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using SuperFluid.Internal.Definitions;
 using SuperFluid.Internal.Diagnostics;
@@ -169,6 +170,23 @@ internal class FluidGeneratorService
 				ex.GenericArgumentName);
 			return GenerationResult.Failure(diagnostic);
 		}
+		catch (InvalidStateNameIdentifierException ex)
+		{
+			Diagnostic diagnostic = Diagnostic.Create(
+				DiagnosticDescriptors.InvalidStateNameIdentifier,
+				Location.None,
+				ex.DeclaredName);
+			return GenerationResult.Failure(diagnostic);
+		}
+		catch (AmbiguousStateNameDeclarationException ex)
+		{
+			Diagnostic diagnostic = Diagnostic.Create(
+				DiagnosticDescriptors.AmbiguousStateNameDeclaration,
+				Location.None,
+				ex.FirstName,
+				ex.SecondName);
+			return GenerationResult.Failure(diagnostic);
+		}
 		catch (Exception ex)
 		{
 			Diagnostic diagnostic = Diagnostic.Create(
@@ -176,6 +194,16 @@ internal class FluidGeneratorService
 				Location.None,
 				ex.Message);
 			return GenerationResult.Failure(diagnostic);
+		}
+
+		// Emit SF0014 warnings for user-declared state names that matched no synthesised state
+		List<Diagnostic> warnings = new();
+		foreach (string unmatchedName in model.UnmatchedStateNameWarnings)
+		{
+			warnings.Add(Diagnostic.Create(
+				DiagnosticDescriptors.UnmatchedStateNameDeclaration,
+				Location.None,
+				unmatchedName));
 		}
 
 		// Check for empty states
@@ -192,7 +220,7 @@ internal class FluidGeneratorService
 		try
 		{
 			newSourceFiles = model.States.ToDictionary(
-				s => $"{s.Name}.fluid.g.cs",
+				s => $"{model.StateNames[s]}.fluid.g.cs",
 				s => GenerateStateSource(s, model));
 		}
 		catch (ArgumentException ex) when (ex.Message.Contains("same key"))
@@ -206,7 +234,9 @@ internal class FluidGeneratorService
 
 		newSourceFiles.Add($"{model.Name}.fluid.g.cs", GenerateCompoundInterface(model));
 
-		return GenerationResult.Success(newSourceFiles);
+		return warnings.Count > 0
+			? GenerationResult.SuccessWithWarnings(newSourceFiles, warnings)
+			: GenerationResult.Success(newSourceFiles);
 	}
 
 	private bool IsValidNamespace(string namespaceName)
@@ -223,24 +253,24 @@ internal class FluidGeneratorService
 		string source = $$"""
 							namespace {{model.Namespace}};
 
-							public interface {{model.Name}}: {{string.Join(",", model.States.Select(s => s.Name).OrderBy(n => n, StringComparer.Ordinal))}}
+							public interface {{model.Name}}: {{string.Join(",", model.States.Select(s => model.StateNames[s]).OrderBy(n => n, StringComparer.Ordinal))}}
 							{
-								public static abstract {{model.InitializerMethodReturnState.Name}} {{model.InitialMethod.Name}}({{string.Join(", ", model.InitialMethod.Arguments.Select(a =>$"{a.Type} {a.Name}"))}});
+								public static abstract {{model.StateNames[model.InitializerMethodReturnState]}} {{model.InitialMethod.Name}}({{string.Join(", ", model.InitialMethod.Arguments.Select(a =>$"{a.Type} {a.Name}"))}});
 							}
 							""";
 		return source;
 	}
 
-	private string GenerateStateSource(FluidApiState fluidApiState, FluidApiModel model) 
+	private string GenerateStateSource(FluidApiState fluidApiState, FluidApiModel model)
 	{
 		IEnumerable<string> methodDeclarations = fluidApiState.MethodTransitions
 			.OrderBy(kvp => kvp.Key.Name, StringComparer.Ordinal)
-			.Select(kvp => GenerateMethodSource(kvp.Key, kvp.Value));
+			.Select(kvp => GenerateMethodSource(kvp.Key, kvp.Value, model));
 
 		string source = $$"""
 						namespace {{model.Namespace}};
-						
-						public interface {{fluidApiState.Name}}
+
+						public interface {{model.StateNames[fluidApiState]}}
 						{
 						{{string.Join("\n", methodDeclarations)}}
 						}
@@ -249,14 +279,14 @@ internal class FluidGeneratorService
 		return source;
 	}
 
-	private string GenerateMethodSource(FluidApiMethod method, FluidApiState state)
+	private string GenerateMethodSource(FluidApiMethod method, FluidApiState state, FluidApiModel model)
 	{
 		string genericArgs = method.GenericArguments.Length > 0 ? $"<{string.Join(",", method.GenericArguments.Select(a => $"{a.Name}"))}>" : string.Empty;
 
 		string constraints = method.GenericArguments.Length > 0 ? $" {string.Join(" ", method.GenericArguments.Select(GenerateGenericConstraintSource))}" : string.Empty;
 
 		return $"""
-		        	public {method.ReturnType ?? state.Name} {method.Name}{genericArgs}({string.Join(", ", method.Arguments.Select(GenerateMethodArgsSource))}){constraints};
+		        	public {method.ReturnType ?? model.StateNames[state]} {method.Name}{genericArgs}({string.Join(", ", method.Arguments.Select(GenerateMethodArgsSource))}){constraints};
 		        """;
 	}
 

--- a/src/SuperFluid/Internal/Services/FluidGeneratorService.cs
+++ b/src/SuperFluid/Internal/Services/FluidGeneratorService.cs
@@ -250,12 +250,14 @@ internal class FluidGeneratorService
 
 	private string GenerateCompoundInterface(FluidApiModel model)
 	{
+		string interfaceDoc = FormatXmlDoc(model.Description, "");
+		string initMethodDoc = FormatXmlDoc(model.InitialMethod.Description, "\t");
 		string source = $$"""
 							namespace {{model.Namespace}};
 
-							public interface {{model.Name}}: {{string.Join(",", model.States.Select(s => model.StateNames[s]).OrderBy(n => n, StringComparer.Ordinal))}}
+							{{interfaceDoc}}public interface {{model.Name}}: {{string.Join(",", model.States.Select(s => model.StateNames[s]).OrderBy(n => n, StringComparer.Ordinal))}}
 							{
-								public static abstract {{model.StateNames[model.InitializerMethodReturnState]}} {{model.InitialMethod.Name}}({{string.Join(", ", model.InitialMethod.Arguments.Select(a =>$"{a.Type} {a.Name}"))}});
+							{{initMethodDoc}}	public static abstract {{model.StateNames[model.InitializerMethodReturnState]}} {{model.InitialMethod.Name}}({{string.Join(", ", model.InitialMethod.Arguments.Select(a =>$"{a.Type} {a.Name}"))}});
 							}
 							""";
 		return source;
@@ -285,9 +287,40 @@ internal class FluidGeneratorService
 
 		string constraints = method.GenericArguments.Length > 0 ? $" {string.Join(" ", method.GenericArguments.Select(GenerateGenericConstraintSource))}" : string.Empty;
 
-		return $"""
-		        	public {method.ReturnType ?? model.StateNames[state]} {method.Name}{genericArgs}({string.Join(", ", method.Arguments.Select(GenerateMethodArgsSource))}){constraints};
-		        """;
+		string doc = FormatXmlDoc(method.Description, "\t");
+
+		return $"{doc}\tpublic {method.ReturnType ?? model.StateNames[state]} {method.Name}{genericArgs}({string.Join(", ", method.Arguments.Select(GenerateMethodArgsSource))}){constraints};";
+	}
+
+	/// <summary>
+	/// Returns a formatted XML documentation block for the given description, with each line prefixed by
+	/// <paramref name="indent"/> and "/// ". Returns an empty string when the description is null or whitespace.
+	/// The returned string ends with a newline so it can be prepended directly before the declaration it documents.
+	/// </summary>
+	private static string FormatXmlDoc(string? description, string indent)
+	{
+		if (string.IsNullOrWhiteSpace(description))
+			return string.Empty;
+
+		string escaped = description!
+			.Replace("&", "&amp;")
+			.Replace("<", "&lt;")
+			.Replace(">", "&gt;");
+
+		string[] lines = escaped.Split('\n');
+
+		System.Text.StringBuilder sb = new();
+		sb.AppendLine($"{indent}/// <summary>");
+		foreach (string line in lines)
+		{
+			string trimmed = line.TrimEnd();
+			if (trimmed.Length > 0)
+				sb.AppendLine($"{indent}/// {trimmed}");
+			else
+				sb.AppendLine($"{indent}///");
+		}
+		sb.AppendLine($"{indent}/// </summary>");
+		return sb.ToString();
 	}
 
 	private string GenerateMethodArgsSource(FluidApiArgument a)

--- a/src/SuperFluid/Internal/Services/GenerationResult.cs
+++ b/src/SuperFluid/Internal/Services/GenerationResult.cs
@@ -12,6 +12,9 @@ internal record GenerationResult(
 	public static GenerationResult Success(Dictionary<string, string> files)
 		=> new(files, ImmutableArray<Diagnostic>.Empty, true);
 
+	public static GenerationResult SuccessWithWarnings(Dictionary<string, string> files, IEnumerable<Diagnostic> warnings)
+		=> new(files, ImmutableArray.CreateRange(warnings), true);
+
 	public static GenerationResult Failure(params Diagnostic[] diagnostics)
 		=> new(null, ImmutableArray.Create(diagnostics), false);
 }

--- a/src/SuperFluid/Internal/Services/StateNamingService.cs
+++ b/src/SuperFluid/Internal/Services/StateNamingService.cs
@@ -1,0 +1,299 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Text;
+using Microsoft.CodeAnalysis.CSharp;
+using SuperFluid.Internal.Definitions;
+using SuperFluid.Internal.EqualityComparers;
+using SuperFluid.Internal.Exceptions;
+using SuperFluid.Internal.Model;
+
+namespace SuperFluid.Internal.Services;
+
+/// <summary>
+/// Computes state interface names using a four-tier scheme:
+///   Tier 1 — full short form  (ICan{M1}Or{M2}...),     if ≤ 60 chars
+///   Tier 2 — truncated form   (ICan{M1}Or{M2}OrNMore), if no collision with another state in the same model
+///   Tier 3 — bucket/hash form (ICanDoMany{Actor}State{hash6})
+///   Tier 4 — user override    (name from StateNames: in YAML)
+/// </summary>
+internal static class StateNamingService
+{
+	private const int ShortFormMaxLength  = 60;
+	private const int FullFormHardCeiling = 200;
+
+	/// <summary>
+	/// Computes a name for each <see cref="FluidApiState"/> in <paramref name="states"/>.
+	/// Applies user overrides first, then auto-tiers.
+	/// Throws typed exceptions for invalid user declarations which the caller converts to diagnostics.
+	/// </summary>
+	/// <returns>A tuple of (name lookup, SF0014 warning names).</returns>
+	public static (Dictionary<FluidApiState, string> Names, List<string> UnmatchedWarnings) AssignNames(
+		List<FluidApiState> states,
+		FluidApiDefinition  definition)
+	{
+		Dictionary<FluidApiState, string> names             = new();
+		List<string>                      unmatchedWarnings = new();
+		HashSet<FluidApiState>            userNamedStates   = new();
+
+		// --- Tier 4: user overrides ---
+		if (definition.StateNames is { Count: > 0 })
+		{
+			// Build a lookup from transition-set → FluidApiState using the existing comparer
+			Dictionary<HashSet<FluidApiMethod>, FluidApiState> transitionMap = BuildTransitionMap(states);
+
+			// Validate all C# identifiers up-front before applying any overrides (SF0015 — error, abort)
+			foreach (StateNameDefinition entry in definition.StateNames)
+			{
+				if (!SyntaxFacts.IsValidIdentifier(entry.Name))
+				{
+					throw new InvalidStateNameIdentifierException(entry.Name);
+				}
+			}
+
+			// Track which synthesised state has been claimed to detect SF0016
+			Dictionary<FluidApiState, string> claimedBy = new();
+
+			foreach (StateNameDefinition entry in definition.StateNames)
+			{
+				HashSet<FluidApiMethod> requestedTransitionSet = ResolveTransitions(entry.Transitions, states);
+
+				if (!transitionMap.TryGetValue(requestedTransitionSet, out FluidApiState? matchedState))
+				{
+					// SF0014 — warning, not fatal
+					unmatchedWarnings.Add(entry.Name);
+					continue;
+				}
+
+				// SF0016 — two entries claim the same synthesised state
+				if (claimedBy.TryGetValue(matchedState, out string? previousName))
+				{
+					throw new AmbiguousStateNameDeclarationException(previousName, entry.Name);
+				}
+
+				claimedBy[matchedState] = entry.Name;
+				userNamedStates.Add(matchedState);
+				names[matchedState] = entry.Name;
+			}
+		}
+
+		// --- Auto-tier: only states not already named by user ---
+		List<FluidApiState> unnamedStates = states.FindAll(s => !userNamedStates.Contains(s));
+		AssignAutoNames(unnamedStates, definition, names);
+
+		return (names, unmatchedWarnings);
+	}
+
+	// -------------------------------------------------------------------------
+
+	private static void AssignAutoNames(
+		List<FluidApiState>               states,
+		FluidApiDefinition                definition,
+		Dictionary<FluidApiState, string> names)
+	{
+		if (states.Count == 0)
+		{
+			return;
+		}
+
+		string actorName = StripLeadingI(definition.Name);
+
+		// Compute the Tier-1 full name for every unnamed state
+		List<(FluidApiState State, string Tier1Name)> tier1Results = new();
+		foreach (FluidApiState state in states)
+		{
+			tier1Results.Add((state, ComputeTier1Name(state)));
+		}
+
+		// States whose Tier-1 name fits within the short-form limit use Tier 1 directly
+		List<(FluidApiState State, string Tier1Name)> needTiering = new();
+		foreach ((FluidApiState state, string tier1Name) in tier1Results)
+		{
+			if (tier1Name.Length <= ShortFormMaxLength)
+			{
+				names[state] = tier1Name;
+			}
+			else
+			{
+				needTiering.Add((state, tier1Name));
+			}
+		}
+
+		if (needTiering.Count == 0)
+		{
+			return;
+		}
+
+		// Compute Tier-2 candidates and find collisions within this model
+		List<(FluidApiState State, string Tier2Name)> tier2Candidates = new();
+		foreach ((FluidApiState state, _) in needTiering)
+		{
+			tier2Candidates.Add((state, ComputeTier2Name(state)));
+		}
+
+		HashSet<string> collidingTier2Names = FindCollisions(tier2Candidates);
+
+		foreach ((FluidApiState state, string tier2Name) in tier2Candidates)
+		{
+			string tier1Name = ComputeTier1Name(state);
+
+			if (tier1Name.Length > FullFormHardCeiling)
+			{
+				// Exceeds the hard ceiling — skip straight to Tier 3
+				names[state] = ComputeTier3Name(state, actorName);
+			}
+			else if (!collidingTier2Names.Contains(tier2Name))
+			{
+				// Tier-2 name is unique within this model — safe to use
+				names[state] = tier2Name;
+			}
+			else
+			{
+				// Tier-2 collision — promote to Tier 3
+				names[state] = ComputeTier3Name(state, actorName);
+			}
+		}
+	}
+
+	// -------------------------------------------------------------------------
+
+	private static string ComputeTier1Name(FluidApiState state)
+	{
+		string joined = state.MethodTransitions.Keys
+							 .Select(m => m.Name)
+							 .OrderBy(n => n, StringComparer.Ordinal)
+							 .Aggregate((a, b) => $"{a}Or{b}");
+		return $"ICan{joined}";
+	}
+
+	private static string ComputeTier2Name(FluidApiState state)
+	{
+		List<string> sorted = state.MethodTransitions.Keys
+								   .Select(m => m.Name)
+								   .OrderBy(n => n, StringComparer.Ordinal)
+								   .ToList();
+
+		string first  = sorted[0];
+		string second = sorted.Count > 1 ? sorted[1] : string.Empty;
+		int    rest   = sorted.Count - 2;
+
+		if (sorted.Count <= 2)
+		{
+			// Tier 2 should only be called for states with > 2 methods;
+			// fall back gracefully
+			return $"ICan{first}" + (second.Length > 0 ? $"Or{second}" : string.Empty);
+		}
+
+		return $"ICan{first}Or{second}Or{rest}More";
+	}
+
+	private static string ComputeTier3Name(FluidApiState state, string actorName)
+	{
+		string hash6 = ComputeHash6(state);
+		return $"ICanDoMany{actorName}State{hash6}";
+	}
+
+	private static string ComputeHash6(FluidApiState state)
+	{
+		string combined = state.MethodTransitions.Keys
+							   .Select(m => m.Name)
+							   .OrderBy(n => n, StringComparer.Ordinal)
+							   .Aggregate((a, b) => $"{a}|{b}");
+
+		byte[] inputBytes = Encoding.UTF8.GetBytes(combined);
+		byte[] hashBytes;
+
+		// SHA256.HashData is not available on netstandard2.0; use SHA256.Create().ComputeHash()
+		using (SHA256 sha256 = SHA256.Create())
+		{
+			hashBytes = sha256.ComputeHash(inputBytes);
+		}
+
+		// Convert.ToHexString is not available on netstandard2.0; use BitConverter
+		string hex = BitConverter.ToString(hashBytes).Replace("-", string.Empty).ToLowerInvariant();
+		return hex.Substring(0, 6);
+	}
+
+	private static HashSet<string> FindCollisions(List<(FluidApiState State, string Tier2Name)> candidates)
+	{
+		HashSet<string> seen      = new(StringComparer.Ordinal);
+		HashSet<string> colliding = new(StringComparer.Ordinal);
+
+		foreach ((_, string name) in candidates)
+		{
+			if (!seen.Add(name))
+			{
+				colliding.Add(name);
+			}
+		}
+
+		return colliding;
+	}
+
+	private static string StripLeadingI(string name)
+	{
+		if (name.Length > 1 && name[0] == 'I' && char.IsUpper(name[1]))
+		{
+			return name.Substring(1);
+		}
+
+		return name;
+	}
+
+	// -------------------------------------------------------------------------
+
+	/// <summary>
+	/// Builds a map from transition-set → <see cref="FluidApiState"/> for all supplied states.
+	/// </summary>
+	private static Dictionary<HashSet<FluidApiMethod>, FluidApiState> BuildTransitionMap(List<FluidApiState> states)
+	{
+		HashSetSetEqualityComparer<FluidApiMethod>         comparer = new();
+		Dictionary<HashSet<FluidApiMethod>, FluidApiState> map      = new(comparer);
+
+		foreach (FluidApiState state in states)
+		{
+			HashSet<FluidApiMethod> transitionSet = new(state.MethodTransitions.Keys);
+			if (!map.ContainsKey(transitionSet))
+			{
+				map[transitionSet] = state;
+			}
+		}
+
+		return map;
+	}
+
+	/// <summary>
+	/// Resolves a list of method name strings to the corresponding <see cref="FluidApiMethod"/> instances,
+	/// returning a <see cref="HashSet{T}"/> suitable for matching against state transition sets.
+	/// Throws <see cref="MethodNotFoundException"/> if a name is not found.
+	/// </summary>
+	private static HashSet<FluidApiMethod> ResolveTransitions(List<string> methodNames, List<FluidApiState> states)
+	{
+		// Build a flat lookup of all known methods across all states
+		Dictionary<string, FluidApiMethod> allMethods = new(StringComparer.Ordinal);
+		foreach (FluidApiState state in states)
+		{
+			foreach (FluidApiMethod method in state.MethodTransitions.Keys)
+			{
+				if (!allMethods.ContainsKey(method.Name))
+				{
+					allMethods[method.Name] = method;
+				}
+			}
+		}
+
+		HashSet<FluidApiMethod> result = new();
+		foreach (string name in methodNames)
+		{
+			if (!allMethods.TryGetValue(name, out FluidApiMethod? method))
+			{
+				throw new MethodNotFoundException("StateNames", name);
+			}
+
+			result.Add(method);
+		}
+
+		return result;
+	}
+}


### PR DESCRIPTION
## Summary

Three independent checklist items bundled into one PR. Commits are logically separable and land in this order:

1. **`b345f2a` chore: drop 4.4 (multi-target framework support)** — Roslyn source generators must load as netstandard2.0; a net8.0 build would sit unused in the analyzer nupkg. No runtime-library consumer either (`DevelopmentDependency=true`, `IncludeBuildOutput=false`).

2. **`e5ffb43` feat: tiered state interface names** — auto-generated state names became long and unwieldy once transition sets grew. Four-tier scheme:
   - Tier 1: full `ICan{M1}Or{M2}Or…` when ≤ 60 chars (today's behaviour for small states; demo fixture byte-identical).
   - Tier 2: truncated `ICan{M1}Or{M2}Or{N}More` when Tier 1 would exceed 60 chars.
   - Tier 3: bucket `ICanDoMany{ActorName}State{hash6}` (6-char SHA-256) for Tier 2 colliders or when Tier 1 exceeds 200 chars.
   - Tier 4: optional `StateNames:` block in YAML for explicit overrides.
   - New diagnostics SF0014 (unmatched override — warning), SF0015 (invalid state identifier — error), SF0016 (ambiguous override — error).
   - Model-layer refactor: `FluidApiState` stays an immutable record (identity-only); state names moved to `Dictionary<FluidApiState, string>` on `FluidApiModel`, populated by a new `StateNamingService`. Preserves the model-layer immutability invariant.

3. **`e5ec8e2` feat: XML doc support for generated interfaces** — optional `Description` fields in YAML flow through to `/// <summary>` comments:
   - Root `FluidApiDefinition.Description` → compound interface summary.
   - `FluidApiMethodDefinition.Description` → per-method summary in every state interface that lists the method (plus the initial-state method on the compound interface).
   - New `FormatXmlDoc` helper escapes `&`, `<`, `>` and handles multi-line descriptions.
   - Missing descriptions produce no `///` output at all.
   - State interfaces intentionally undocumented — synthesised from transition sets with no natural YAML attach point.
   - Also marks checklist item 3.2 (file-scoped namespaces in generated code) as complete — verified already done.

## Test plan

- [x] `dotnet build src/SuperFluid.sln` — 0 warnings, 0 errors
- [x] `dotnet test src/SuperFluid.sln` — 61/61 passing (47 baseline + 8 tiered state + 6 XML doc)
- [ ] Manual: inspect generated `obj/**/generated/**/*.g.cs` for a Tier 3 case
- [ ] Manual: inspect a build with descriptions set to confirm XML doc indentation / escaping

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added XML documentation support for generated interfaces and methods, with automatic generation of `<summary>` blocks from descriptions.
  * Introduced custom state naming with validation, supporting user-defined state names and tiered auto-naming strategy.
  * Enhanced diagnostics with three new warning/error codes for state naming validation.

* **Tests**
  * Expanded test coverage for state naming tiers, XML documentation emission, and diagnostic validation.

* **Documentation**
  * Updated modernisation checklist with completion status and technical notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->